### PR TITLE
Update Flink deps to 1.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <java.version>11</java.version>
         <aws.sdk.version>2.15.65</aws.sdk.version>
         <scala.binary.version>2.12</scala.binary.version>
-        <flink.version>1.11.3</flink.version>
+        <flink.version>1.15.1</flink.version>
         <junit.jupiter.version>5.6.2</junit.jupiter.version>
         <guava.version>30.1-jre</guava.version>
         <mockito.version>3.1.0</mockito.version>
@@ -165,7 +165,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
         </dependency>
         <dependency>
@@ -188,20 +188,20 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-test-utils_${scala.binary.version}</artifactId>
+            <artifactId>flink-test-utils</artifactId>
             <version>${flink.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-runtime_${scala.binary.version}</artifactId>
+            <artifactId>flink-runtime</artifactId>
             <version>${flink.version}</version>
             <scope>test</scope>
             <classifier>tests</classifier>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
             <scope>test</scope>
             <classifier>tests</classifier>


### PR DESCRIPTION
Hey there, we wanted to use this connector with Flink 1.15 but noticed it was built against a considerably older version. After making a few changes in deps and building our own version we were pleasantly suprised to see it was doing just fine with no other code changes needed. 
So I'm opening this PR to ask if you would consider merging the version bump and releasing a new version so we (and possibly other users of current Flink versions) can use it in our dependency resolution instead of our private one.

I'm also adding a logging code snippet that helped me when I was debugging issues with DynamoDB.